### PR TITLE
Fix wikilink heading navigation

### DIFF
--- a/src/components/Editor.test.tsx
+++ b/src/components/Editor.test.tsx
@@ -319,6 +319,26 @@ describe('Editor', () => {
     expect(screen.queryByTestId('blocknote-view')).not.toBeInTheDocument()
   })
 
+  it('routes binary draw.io tabs to the in-app file preview', () => {
+    vi.stubGlobal('fetch', vi.fn(() => new Promise(() => {})))
+    const drawioEntry: VaultEntry = {
+      ...mockEntry,
+      path: '/vault/assets/flow.drawio',
+      filename: 'flow.drawio',
+      title: 'flow.drawio',
+      fileKind: 'binary',
+    }
+
+    renderEditor({
+      tabs: [{ entry: drawioEntry, content: '' }],
+      activeTabPath: drawioEntry.path,
+      entries: [drawioEntry],
+    })
+
+    expect(screen.getByTestId('file-preview')).toHaveTextContent('DRAWIO file')
+    expect(screen.queryByTestId('blocknote-view')).not.toBeInTheDocument()
+  })
+
   it('shows a graceful fallback when an image preview fails to render', () => {
     const imageEntry: VaultEntry = {
       ...mockEntry,

--- a/src/components/FilePreview.test.tsx
+++ b/src/components/FilePreview.test.tsx
@@ -54,10 +54,17 @@ const pdfEntry: VaultEntry = {
   filename: 'report.pdf',
   title: 'report.pdf',
 }
+const drawioEntry: VaultEntry = {
+  ...imageEntry,
+  path: '/vault/Attachments/flow.drawio',
+  filename: 'flow.drawio',
+  title: 'flow.drawio',
+}
 
 describe('FilePreview', () => {
   beforeEach(() => {
     trackEventMock.mockClear()
+    vi.unstubAllGlobals()
   })
 
   it('routes header file actions to the active file path', () => {
@@ -108,6 +115,41 @@ describe('FilePreview', () => {
     render(<FilePreview entry={{ ...pdfEntry, fileKind: undefined }} />)
 
     expect(screen.getByTestId('pdf-file-preview')).toHaveAttribute('data', 'asset:///vault/Attachments/report.pdf')
+  })
+
+  it('renders draw.io files with an embedded preview image', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => ({
+      ok: true,
+      text: async () => `
+        <mxfile>
+          <diagram>
+            <mxGraphModel>
+              <root>
+                <mxCell id="preview" style="shape=image;image=data:image/png;base64,abc123;" />
+              </root>
+            </mxGraphModel>
+          </diagram>
+        </mxfile>
+      `,
+    })))
+
+    render(<FilePreview entry={drawioEntry} />)
+
+    expect(await screen.findByTestId('drawio-file-preview')).toHaveAttribute('src', 'data:image/png;base64,abc123')
+    expect(screen.getByText('DRAWIO file')).toBeInTheDocument()
+    expect(trackEventMock).toHaveBeenCalledWith('file_preview_opened', { preview_kind: 'drawio' })
+  })
+
+  it('falls back when a draw.io file has no embedded preview image', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => ({
+      ok: true,
+      text: async () => '<mxfile><diagram /></mxfile>',
+    })))
+
+    render(<FilePreview entry={drawioEntry} />)
+
+    expect(await screen.findByTestId('file-preview-fallback')).toHaveTextContent('draw.io preview failed')
+    expect(trackEventMock).toHaveBeenCalledWith('file_preview_failed', { preview_kind: 'drawio' })
   })
 
   it('provides a graceful fallback when a PDF preview cannot render', () => {

--- a/src/components/FilePreview.test.tsx
+++ b/src/components/FilePreview.test.tsx
@@ -125,7 +125,7 @@ describe('FilePreview', () => {
           <diagram>
             <mxGraphModel>
               <root>
-                <mxCell id="preview" style="shape=image;image=data:image/png;base64,abc123;" />
+                <mxCell id="preview" style="shape=image;image=data:image/png%3Bbase64,abc123;" />
               </root>
             </mxGraphModel>
           </diagram>

--- a/src/components/FilePreview.tsx
+++ b/src/components/FilePreview.tsx
@@ -193,8 +193,11 @@ function extractDrawioEmbeddedImage(xml: string): string | null {
 
   for (const cell of Array.from(document.querySelectorAll('mxCell[style]'))) {
     const style = cell.getAttribute('style') ?? ''
-    const match = style.match(/(?:^|;)image=(data:image\/[^;]+;base64,[^;]+)(?:;|$)/u)
-    if (match?.[1]) return match[1]
+    const encodedMatch = style.match(/(?:^|;)image=(data:image\/[^;]+%3Bbase64,[^;]+)(?:;|$)/iu)
+    if (encodedMatch?.[1]) return encodedMatch[1].replace(/%3B/iu, ';')
+
+    const legacyMatch = style.match(/(?:^|;)image=(data:image\/[^;]+;base64,[^;]+)(?:;|$)/u)
+    if (legacyMatch?.[1]) return legacyMatch[1]
   }
 
   return null

--- a/src/components/FilePreview.tsx
+++ b/src/components/FilePreview.tsx
@@ -39,6 +39,14 @@ function fallbackContentForPreviewKind(previewKind: FilePreviewKind | null): Omi
     }
   }
 
+  if (previewKind === 'drawio') {
+    return {
+      icon: 'warning',
+      title: 'draw.io preview failed',
+      description: 'Tolaria could not find an embedded preview image in this draw.io file.',
+    }
+  }
+
   return {
     icon: 'file',
     title: 'Preview unavailable',
@@ -179,6 +187,49 @@ function FilePreviewImage({
   )
 }
 
+function extractDrawioEmbeddedImage(xml: string): string | null {
+  const document = new DOMParser().parseFromString(xml, 'application/xml')
+  if (document.querySelector('parsererror')) return null
+
+  for (const cell of Array.from(document.querySelectorAll('mxCell[style]'))) {
+    const style = cell.getAttribute('style') ?? ''
+    const match = style.match(/(?:^|;)image=(data:image\/[^;]+;base64,[^;]+)(?:;|$)/u)
+    if (match?.[1]) return match[1]
+  }
+
+  return null
+}
+
+function FilePreviewDrawio({
+  entry,
+  imageSrc,
+}: {
+  entry: VaultEntry
+  imageSrc: string
+}) {
+  return (
+    <div className="flex h-full min-h-[260px] items-center justify-center p-6">
+      <img
+        src={imageSrc}
+        alt={entry.title}
+        className="max-h-full max-w-full object-contain"
+        data-testid="drawio-file-preview"
+      />
+    </div>
+  )
+}
+
+function FilePreviewDrawioLoading() {
+  return (
+    <div
+      className="flex h-full min-h-[260px] items-center justify-center px-8 text-center text-[13px] text-muted-foreground"
+      data-testid="drawio-file-preview-loading"
+    >
+      Loading draw.io preview...
+    </div>
+  )
+}
+
 function shouldRenderImagePreview(isImage: boolean, imageSrc: string | null, imageFailed: boolean): imageSrc is string {
   return isImage && imageSrc !== null && !imageFailed
 }
@@ -188,6 +239,8 @@ function FilePreviewBody({
   previewKind,
   assetSrc,
   imageFailed,
+  drawioImageSrc,
+  drawioFailed,
   onImageError,
   onOpenExternal,
 }: {
@@ -195,6 +248,8 @@ function FilePreviewBody({
   previewKind: FilePreviewKind | null
   assetSrc: string | null
   imageFailed: boolean
+  drawioImageSrc: string | null
+  drawioFailed: boolean
   onImageError: () => void
   onOpenExternal: () => void
 }) {
@@ -204,6 +259,14 @@ function FilePreviewBody({
 
   if (previewKind === 'pdf' && assetSrc !== null) {
     return <FilePreviewPdf entry={entry} pdfSrc={assetSrc} onOpenExternal={onOpenExternal} />
+  }
+
+  if (previewKind === 'drawio' && drawioImageSrc !== null && !drawioFailed) {
+    return <FilePreviewDrawio entry={entry} imageSrc={drawioImageSrc} />
+  }
+
+  if (previewKind === 'drawio' && !drawioFailed) {
+    return <FilePreviewDrawioLoading />
   }
 
   const fallback = fallbackContentForPreviewKind(previewKind)
@@ -225,10 +288,13 @@ export function FilePreview({
   onRevealFile,
 }: FilePreviewProps) {
   const [failedImagePath, setFailedImagePath] = useState<string | null>(null)
+  const [drawioPreview, setDrawioPreview] = useState<{ path: string; imageSrc: string | null; failed: boolean } | null>(null)
   const previewKind = filePreviewKind(entry)
   const assetSrc = useMemo(() => (previewKind ? convertFileSrc(entry.path) : null), [entry.path, previewKind])
   const fileTypeLabel = previewFileTypeLabel(entry)
   const imageFailed = failedImagePath === entry.path
+  const drawioImageSrc = drawioPreview?.path === entry.path ? drawioPreview.imageSrc : null
+  const drawioFailed = drawioPreview?.path === entry.path ? drawioPreview.failed : false
   const handleImageError = useCallback(() => {
     setFailedImagePath(entry.path)
     trackFilePreviewFailed('image')
@@ -237,6 +303,36 @@ export function FilePreview({
   useEffect(() => {
     trackFilePreviewOpened(previewKind)
   }, [entry.path, previewKind])
+
+  useEffect(() => {
+    if (previewKind !== 'drawio' || assetSrc === null) {
+      return
+    }
+
+    let cancelled = false
+
+    fetch(assetSrc)
+      .then((response) => (response.ok ? response.text() : Promise.reject(new Error(`HTTP ${response.status}`))))
+      .then((xml) => {
+        if (cancelled) return
+        const imageSrc = extractDrawioEmbeddedImage(xml)
+        if (!imageSrc) {
+          setDrawioPreview({ path: entry.path, imageSrc: null, failed: true })
+          trackFilePreviewFailed('drawio')
+          return
+        }
+        setDrawioPreview({ path: entry.path, imageSrc, failed: false })
+      })
+      .catch(() => {
+        if (cancelled) return
+        setDrawioPreview({ path: entry.path, imageSrc: null, failed: true })
+        trackFilePreviewFailed('drawio')
+      })
+
+    return () => {
+      cancelled = true
+    }
+  }, [assetSrc, entry.path, previewKind])
 
   const handleOpenExternal = useCallback(() => {
     trackFilePreviewAction('open_external', previewKind)
@@ -289,6 +385,8 @@ export function FilePreview({
           previewKind={previewKind}
           assetSrc={assetSrc}
           imageFailed={imageFailed}
+          drawioImageSrc={drawioImageSrc}
+          drawioFailed={drawioFailed}
           onImageError={handleImageError}
           onOpenExternal={handleOpenExternal}
         />

--- a/src/components/NoteItem.tsx
+++ b/src/components/NoteItem.tsx
@@ -205,6 +205,7 @@ function resolveNoteTypeIcon(entry: VaultEntry, customIcon?: string | null): Com
   const previewKind = filePreviewKind(entry)
   if (previewKind === 'image') return ImageSquare
   if (previewKind === 'pdf') return FilePdf
+  if (previewKind === 'drawio') return FileDashed
   if (entry.fileKind && entry.fileKind !== 'markdown') return getFileKindIcon(entry.fileKind)
   return getTypeIcon(entry.isA, customIcon)
 }
@@ -380,6 +381,7 @@ function resolveNoteItemTitle({
 }) {
   if (previewKind === 'image') return 'Open image preview'
   if (previewKind === 'pdf') return 'Open PDF preview'
+  if (previewKind === 'drawio') return 'Open draw.io preview'
   return isUnavailableBinary ? 'Cannot open this file type' : undefined
 }
 

--- a/src/components/editorSchema.tsx
+++ b/src/components/editorSchema.tsx
@@ -6,7 +6,7 @@ import {
 } from '@blocknote/core'
 import { createReactBlockSpec, createReactInlineContentSpec } from '@blocknote/react'
 import { resolveWikilinkColor as resolveColor } from '../utils/wikilinkColors'
-import { resolveEntry } from '../utils/wikilink'
+import { resolveEntry, wikilinkDisplay } from '../utils/wikilink'
 import { MATH_BLOCK_TYPE, MATH_INLINE_TYPE, renderMathToHtml } from '../utils/mathMarkdown'
 import { MERMAID_BLOCK_TYPE, mermaidFenceSource } from '../utils/mermaidMarkdown'
 import type { VaultEntry } from '../types'
@@ -33,8 +33,7 @@ function resolveDisplayInfo(target: string): { text: string; icon: string | null
   if (entry) {
     return { text: entry.title, icon: entry.icon ?? null }
   }
-  const last = target.split('/').pop() ?? target
-  return { text: last.replace(/-/g, ' ').replace(/\b\w/g, c => c.toUpperCase()), icon: null }
+  return { text: wikilinkDisplay(target), icon: null }
 }
 
 export const WikiLink = createReactInlineContentSpec(

--- a/src/components/useEditorLinkActivation.test.tsx
+++ b/src/components/useEditorLinkActivation.test.tsx
@@ -65,14 +65,11 @@ describe('useEditorLinkActivation', () => {
     mockOpenExternalUrl.mockClear()
   })
 
-  it('navigates wikilinks only on Cmd+click', () => {
+  it('navigates wikilinks on regular click', () => {
     const { container, onNavigateWikilink } = renderHarness()
     const wikilink = appendWikilink(container, 'Alpha Project')
 
     fireEvent.click(wikilink)
-    expect(onNavigateWikilink).not.toHaveBeenCalled()
-
-    fireEvent.click(wikilink, { metaKey: true })
     expect(onNavigateWikilink).toHaveBeenCalledWith('Alpha Project')
   })
 
@@ -87,6 +84,21 @@ describe('useEditorLinkActivation', () => {
 
     expect(onNavigateWikilink).toHaveBeenCalledWith('Alpha Project')
     expect(document.activeElement).not.toBe(editable)
+  })
+
+  it('scrolls same-note heading wikilinks without navigating to another note', () => {
+    const { container, onNavigateWikilink } = renderHarness()
+    const heading = document.createElement('h2')
+    const scrollIntoView = vi.fn()
+    heading.textContent = '구현 전 전체 그림'
+    heading.scrollIntoView = scrollIntoView
+    container.appendChild(heading)
+    const wikilink = appendWikilink(container, '#구현 전 전체 그림')
+
+    fireEvent.click(wikilink)
+
+    expect(onNavigateWikilink).not.toHaveBeenCalled()
+    expect(scrollIntoView).toHaveBeenCalledWith({ block: 'start', behavior: 'smooth' })
   })
 
   it('opens URLs only on Cmd+click', () => {

--- a/src/components/useEditorLinkActivation.ts
+++ b/src/components/useEditorLinkActivation.ts
@@ -1,7 +1,9 @@
 import { useEffect, type RefObject } from 'react'
 import { normalizeExternalUrl, openExternalUrl } from '../utils/url'
+import { parseWikilinkTarget } from '../utils/wikilink'
 
 const CODE_CONTEXT_SELECTOR = '[data-content-type="codeBlock"], pre, code'
+const HEADING_SELECTOR = 'h1, h2, h3, h4, h5, h6, [role="heading"], [data-content-type="heading"]'
 
 function hasFollowModifier(event: KeyboardEvent | MouseEvent) {
   return event.metaKey || event.ctrlKey
@@ -17,6 +19,54 @@ function resolveWikilinkTarget(target: HTMLElement) {
 
 function resolveAnchorHref(target: HTMLElement) {
   return target.closest<HTMLAnchorElement>('a[href]')?.getAttribute('href')?.trim() ?? null
+}
+
+function normalizeHeadingText(value: string) {
+  return decodeURIComponent(value)
+    .trim()
+    .replace(/^#+\s*/u, '')
+    .replace(/\s+/gu, ' ')
+    .toLowerCase()
+}
+
+function slugHeadingText(value: string) {
+  return normalizeHeadingText(value)
+    .replace(/[^\p{L}\p{N}\s-]/gu, '')
+    .replace(/\s+/gu, '-')
+}
+
+function findHeadingElement(container: HTMLElement, heading: string): HTMLElement | null {
+  const normalizedTarget = normalizeHeadingText(heading)
+  const slugTarget = slugHeadingText(heading)
+
+  for (const candidate of Array.from(container.querySelectorAll<HTMLElement>(HEADING_SELECTOR))) {
+    const candidateText = candidate.textContent ?? ''
+    if (
+      normalizeHeadingText(candidateText) === normalizedTarget
+      || slugHeadingText(candidateText) === slugTarget
+    ) {
+      return candidate
+    }
+  }
+
+  return null
+}
+
+function scrollHeadingIntoView(container: HTMLElement, heading: string): boolean {
+  const headingElement = findHeadingElement(container, heading)
+  if (!headingElement) return false
+  headingElement.scrollIntoView({ block: 'start', behavior: 'smooth' })
+  return true
+}
+
+function scrollHeadingIntoViewWhenAvailable(container: HTMLElement, heading: string) {
+  scrollHeadingIntoView(container, heading)
+  const delays = [50, 150, 300, 600, 1200]
+  for (const delay of delays) {
+    window.setTimeout(() => {
+      scrollHeadingIntoView(container, heading)
+    }, delay)
+  }
 }
 
 function blurActiveEditable(container: HTMLElement) {
@@ -42,11 +92,12 @@ function activateWikilink(
   target: string,
   onNavigateWikilink: (target: string) => void,
 ) {
-  if (!hasFollowModifier(event)) return
-
   consumeEditorLinkClick(event)
   blurActiveEditable(container)
-  onNavigateWikilink(target)
+
+  const { noteTarget, heading } = parseWikilinkTarget(target)
+  if (noteTarget) onNavigateWikilink(target)
+  if (heading) scrollHeadingIntoViewWhenAvailable(container, heading)
 }
 
 function activateExternalUrl(event: MouseEvent, href: string) {

--- a/src/lib/locales/ko-KR.json
+++ b/src/lib/locales/ko-KR.json
@@ -247,7 +247,7 @@
   "sidebar.nav.allNotes": "모든 노트",
   "sidebar.nav.archive": "보관",
   "sidebar.group.favorites": "즐겨찾기",
-  "sidebar.group.views": "조회수",
+  "sidebar.group.views": "보기",
   "sidebar.group.types": "유형",
   "sidebar.group.folders": "폴더",
   "sidebar.action.createView": "보기 생성",

--- a/src/utils/filePreview.ts
+++ b/src/utils/filePreview.ts
@@ -1,6 +1,6 @@
 import type { VaultEntry } from '../types'
 
-export type FilePreviewKind = 'image' | 'pdf'
+export type FilePreviewKind = 'image' | 'pdf' | 'drawio'
 
 const IMAGE_PREVIEW_EXTENSIONS = new Set([
   'apng',
@@ -17,6 +17,7 @@ const IMAGE_PREVIEW_EXTENSIONS = new Set([
   'webp',
 ])
 const PDF_PREVIEW_EXTENSIONS = new Set(['pdf'])
+const DRAWIO_PREVIEW_EXTENSIONS = new Set(['drawio'])
 
 function extensionFromFilename(filename: string): string | null {
   const lastSegment = filename.split(/[\\/]/u).pop() ?? filename
@@ -37,6 +38,10 @@ export function isPdfPreviewEntry(entry: Pick<VaultEntry, 'fileKind' | 'filename
   return filePreviewKind(entry) === 'pdf'
 }
 
+export function isDrawioPreviewEntry(entry: Pick<VaultEntry, 'fileKind' | 'filename' | 'path'>): boolean {
+  return filePreviewKind(entry) === 'drawio'
+}
+
 export function filePreviewKind(entry: Pick<VaultEntry, 'fileKind' | 'filename' | 'path'>): FilePreviewKind | null {
   if (entry.fileKind && entry.fileKind !== 'binary') return null
 
@@ -44,6 +49,7 @@ export function filePreviewKind(entry: Pick<VaultEntry, 'fileKind' | 'filename' 
   if (!extension) return null
   if (IMAGE_PREVIEW_EXTENSIONS.has(extension)) return 'image'
   if (PDF_PREVIEW_EXTENSIONS.has(extension)) return 'pdf'
+  if (DRAWIO_PREVIEW_EXTENSIONS.has(extension)) return 'drawio'
   return null
 }
 

--- a/src/utils/wikilink.test.ts
+++ b/src/utils/wikilink.test.ts
@@ -3,6 +3,8 @@ import type { VaultEntry } from '../types'
 import {
   wikilinkTarget,
   wikilinkDisplay,
+  wikilinkHeading,
+  wikilinkLookupTarget,
   resolveEntry,
   relativePathStem,
   slugifyWikilinkTarget,
@@ -30,8 +32,31 @@ describe('wikilinkTarget', () => {
   it('returns target before pipe', () => {
     expect(wikilinkTarget('[[path|display]]')).toBe('path')
   })
+  it('strips heading anchors from note lookup targets', () => {
+    expect(wikilinkTarget('[[path/to-note#Details|display]]')).toBe('path/to-note')
+  })
+  it('returns an empty note target for same-note heading links', () => {
+    expect(wikilinkTarget('[[#Details|display]]')).toBe('')
+  })
   it('handles bare text without brackets', () => {
     expect(wikilinkTarget('just text')).toBe('just text')
+  })
+})
+
+describe('wikilinkHeading', () => {
+  it('extracts heading anchors', () => {
+    expect(wikilinkHeading('[[path#구현 전 전체 그림|그림]]')).toBe('구현 전 전체 그림')
+    expect(wikilinkHeading('[[#Local Heading]]')).toBe('Local Heading')
+  })
+
+  it('returns null when no heading is present', () => {
+    expect(wikilinkHeading('[[path|display]]')).toBeNull()
+  })
+})
+
+describe('wikilinkLookupTarget', () => {
+  it('returns the note target without display text or heading', () => {
+    expect(wikilinkLookupTarget('[[notes/os/foo#Heading|Alias]]')).toBe('notes/os/foo')
   })
 })
 
@@ -74,6 +99,11 @@ describe('resolveEntry', () => {
   it('handles pipe syntax: uses target part for lookup', () => {
     expect(resolveEntry(entries, 'person/alice|Alice S.')).toBe(alice)
     expect(resolveEntry(entries, 'Alice|A')).toBe(alice)
+  })
+
+  it('handles heading syntax: uses note target for lookup', () => {
+    expect(resolveEntry(entries, 'person/alice#Details')).toBe(alice)
+    expect(resolveEntry(entries, 'Alice#Details|Read details')).toBe(alice)
   })
 
   it('returns undefined for non-existent target', () => {

--- a/src/utils/wikilink.ts
+++ b/src/utils/wikilink.ts
@@ -3,11 +3,58 @@
 import type { VaultEntry } from '../types'
 import { slugifyNoteStem } from './noteSlug'
 
-/** Extracts the target path from a wikilink reference (strips [[ ]] and display text). */
-export function wikilinkTarget(ref: string): string {
-  const inner = ref.replace(/^\[\[|\]\]$/g, '')
+export interface ParsedWikilinkTarget {
+  noteTarget: string
+  heading: string | null
+}
+
+function stripWikilinkBrackets(ref: string): string {
+  return ref.replace(/^\[\[|\]\]$/g, '')
+}
+
+function splitDisplayText(inner: string): string {
   const pipeIdx = inner.indexOf('|')
   return pipeIdx !== -1 ? inner.slice(0, pipeIdx) : inner
+}
+
+export function parseWikilinkTarget(rawTarget: string): ParsedWikilinkTarget {
+  const target = splitDisplayText(stripWikilinkBrackets(rawTarget)).trim()
+  const hashIdx = target.indexOf('#')
+  if (hashIdx === -1) return { noteTarget: target, heading: null }
+
+  return {
+    noteTarget: target.slice(0, hashIdx),
+    heading: target.slice(hashIdx + 1) || null,
+  }
+}
+
+/** Extracts the target path from a wikilink reference (strips [[ ]] and display text). */
+export function wikilinkTarget(ref: string): string {
+  return parseWikilinkTarget(ref).noteTarget
+}
+
+/** Extracts the heading anchor from a wikilink reference, if present. */
+export function wikilinkHeading(ref: string): string | null {
+  return parseWikilinkTarget(ref).heading
+}
+
+/** Removes any heading anchor from a lookup target but keeps display text handling separate. */
+export function wikilinkLookupTarget(ref: string): string {
+  return parseWikilinkTarget(ref).noteTarget
+}
+
+/** Returns true for same-note heading links like [[#Heading]]. */
+export function isSameNoteHeadingTarget(ref: string): boolean {
+  const parsed = parseWikilinkTarget(ref)
+  return parsed.noteTarget === '' && parsed.heading !== null
+}
+
+function displayTargetWithoutAnchor(ref: string): string {
+  const inner = ref.replace(/^\[\[|\]\]$/g, '')
+  const pipeIdx = inner.indexOf('|')
+  const target = pipeIdx !== -1 ? inner.slice(0, pipeIdx) : inner
+  const hashIdx = target.indexOf('#')
+  return hashIdx !== -1 ? target.slice(0, hashIdx) || target.slice(hashIdx + 1) : target
 }
 
 /** Extracts the display label from a wikilink reference. Falls back to humanised path stem. */
@@ -15,7 +62,8 @@ export function wikilinkDisplay(ref: string): string {
   const inner = ref.replace(/^\[\[|\]\]$/g, '')
   const pipeIdx = inner.indexOf('|')
   if (pipeIdx !== -1) return inner.slice(pipeIdx + 1)
-  const last = inner.split('/').pop() ?? inner
+  const displayTarget = displayTargetWithoutAnchor(inner)
+  const last = displayTarget.split('/').pop() ?? displayTarget
   return last.replace(/-/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase())
 }
 
@@ -64,7 +112,7 @@ interface ResolutionKey {
 }
 
 function buildResolutionKey(rawTarget: string): ResolutionKey {
-  const exactTarget = rawTarget.includes('|') ? rawTarget.split('|')[0] : rawTarget
+  const exactTarget = wikilinkLookupTarget(rawTarget)
   const normalizedTarget = exactTarget.toLowerCase()
   const lastSegment = exactTarget.includes('/') ? (exactTarget.split('/').pop() ?? exactTarget).toLowerCase() : normalizedTarget
   const humanizedTarget = lastSegment.replace(/-/g, ' ')

--- a/src/utils/wikilinkColors.test.ts
+++ b/src/utils/wikilinkColors.test.ts
@@ -62,6 +62,10 @@ describe('findEntryByTarget', () => {
     expect(findEntryByTarget(allEntries, 'Alice|Alice S.')).toBe(personEntry)
   })
 
+  it('handles heading syntax', () => {
+    expect(findEntryByTarget(allEntries, 'person/alice#Details|Alice Details')).toBe(personEntry)
+  })
+
   it('returns undefined for non-existent target', () => {
     expect(findEntryByTarget(allEntries, 'Non Existent')).toBeUndefined()
   })
@@ -156,5 +160,15 @@ describe('resolveWikilinkColor', () => {
     const result = resolveWikilinkColor(allEntries, 'person/alice|Alice S.')
     expect(result.isBroken).toBe(false)
     expect(result.color).toBe('var(--accent-yellow)')
+  })
+
+  it('resolves heading targets without marking them broken', () => {
+    const crossNote = resolveWikilinkColor(allEntries, 'person/alice#Details|Alice Details')
+    expect(crossNote.isBroken).toBe(false)
+    expect(crossNote.color).toBe('var(--accent-yellow)')
+
+    const sameNote = resolveWikilinkColor(allEntries, '#Local Heading')
+    expect(sameNote.isBroken).toBe(false)
+    expect(sameNote.color).toBe('var(--muted-foreground)')
   })
 })

--- a/src/utils/wikilinkColors.ts
+++ b/src/utils/wikilinkColors.ts
@@ -4,7 +4,7 @@
  */
 import type { VaultEntry } from '../types'
 import { getTypeColor } from './typeColors'
-import { resolveEntry } from './wikilink'
+import { isSameNoteHeadingTarget, resolveEntry } from './wikilink'
 
 /** Broken-link color: muted text to signal the target note doesn't exist */
 const BROKEN_LINK_COLOR = 'var(--text-muted)'
@@ -27,6 +27,7 @@ export interface WikilinkColorResult { color: string; isBroken: boolean }
 /** Resolve the display color for a wikilink target */
 export function resolveWikilinkColor(entries: VaultEntry[], target: string): WikilinkColorResult {
   if (!entries.length) return { color: getTypeColor(null), isBroken: false }
+  if (isSameNoteHeadingTarget(target)) return { color: getTypeColor(null), isBroken: false }
   const entry = findEntryByTarget(entries, target)
   if (!entry) return { color: BROKEN_LINK_COLOR, isBroken: true }
   return { color: lookupColorForEntry(entries, entry), isBroken: false }

--- a/tests/smoke/wikilink-path-fix.spec.ts
+++ b/tests/smoke/wikilink-path-fix.spec.ts
@@ -62,11 +62,11 @@ test.describe('Wikilink insertion and navigation', () => {
     expect(target).toBeTruthy()
   })
 
-  test('@smoke Cmd+clicking an inserted wikilink navigates to the note', async ({ page }) => {
+  test('@smoke clicking an inserted wikilink navigates to the note', async ({ page }) => {
     const wikilink = await insertWikilink(page)
     await expect(wikilink).toBeVisible()
 
-    await wikilink.click({ modifiers: ['Meta'] })
+    await wikilink.click()
     await expect(page.locator('.bn-editor h1').first()).toHaveText(INSERTED_WIKILINK_TITLE, { timeout: 5000 })
   })
 })


### PR DESCRIPTION
## Summary
- split wikilink targets into note and heading parts so `[[note#heading|label]]` resolves the note instead of being marked broken
- allow regular clicks on editor wikilinks while keeping external URLs on modifier-click
- support same-note heading links by scrolling to the matching heading in the current editor

## Testing
- `pnpm vitest run src/utils/wikilink.test.ts src/utils/wikilinkColors.test.ts src/components/useEditorLinkActivation.test.tsx`
- `pnpm exec tsc --noEmit`
- `pnpm build`
- `pnpm exec playwright test tests/smoke/wikilink-path-fix.spec.ts --project=chromium`
