### PR TITLE
fix(ui): keep editor hover controls behind note context menu

### DIFF
--- a/src/components/NoteList.contextMenu.test.tsx
+++ b/src/components/NoteList.contextMenu.test.tsx
@@ -66,8 +66,10 @@ describe('NoteList context menu', () => {
 
     openBuildLaputaActions()
 
-    expect(screen.getByTestId('note-list-context-menu')).toBeInTheDocument()
-    expect(screen.getByTestId('note-list-context-menu')).toHaveClass('z-[12000]')
+    const contextMenu = screen.getByTestId('note-list-context-menu')
+    expect(contextMenu).toBeInTheDocument()
+    expect(contextMenu).toHaveClass('z-[12000]')
+    expect(contextMenu.parentElement).toBe(document.body)
     expect(screen.getByText(getAppCommandShortcutDisplay(APP_COMMAND_IDS.noteOpenInNewWindow)!)).toBeInTheDocument()
     expect(screen.getByText(getAppCommandShortcutDisplay(APP_COMMAND_IDS.noteToggleFavorite)!)).toBeInTheDocument()
     expect(screen.getByText(getAppCommandShortcutDisplay(APP_COMMAND_IDS.noteToggleOrganized)!)).toBeInTheDocument()

--- a/src/components/note-list/NoteListContextMenuView.tsx
+++ b/src/components/note-list/NoteListContextMenuView.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useId, useRef, useState, type FormEvent, type RefObject } from 'react'
+import { createPortal } from 'react-dom'
 import {
   Archive,
   ArrowSquareOut,
@@ -314,7 +315,7 @@ export function NoteListContextMenuNode(props: NoteListContextMenuNodeProps) {
     onCopyGitUrl,
   }, entry, selectAction)
 
-  return (
+  return createPortal(
     <div
       ref={ctxMenuRef}
       className="fixed z-[12000] rounded-md border bg-popover p-1 shadow-md"
@@ -322,7 +323,8 @@ export function NoteListContextMenuNode(props: NoteListContextMenuNodeProps) {
       data-testid="note-list-context-menu"
     >
       {items.map((item) => <NoteListContextMenuButton key={item.label} item={item} />)}
-    </div>
+    </div>,
+    document.body,
   )
 }
 


### PR DESCRIPTION
Closes #1030

## Summary
- render the note-list context menu through a document-body portal
- move the menu out of the note-list stacking context so editor block hover controls cannot appear above it
- add a regression assertion for the portal container

## Validation
- pre-push lint and production build passed
- 5,018 frontend tests passed
- coverage passed (88.71% lines)
- 27 core Playwright smoke tests passed

## Local analysis availability
- CodeScene was skipped by the repository hook because its credentials are not configured locally
- Codacy CLI/integration was not available locally