### PR TITLE
fix(ui): let the last note scroll above the note list filter pills

### DIFF
--- a/src/components/note-list/NoteListLayout.tsx
+++ b/src/components/note-list/NoteListLayout.tsx
@@ -99,6 +99,7 @@ function NoteListContent({
   noteListVirtuosoRef,
   locale,
   loading,
+  showFilterPills,
 }: Pick<
   NoteListLayoutProps,
   | 'entitySelection'
@@ -117,6 +118,7 @@ function NoteListContent({
   | 'noteListVirtuosoRef'
   | 'locale'
   | 'loading'
+  | 'showFilterPills'
 >) {
   return (
     <div className="flex-1 overflow-hidden" style={{ minHeight: 0 }}>
@@ -145,6 +147,7 @@ function NoteListContent({
           renderItem={renderItem}
           virtuosoRef={noteListVirtuosoRef}
           locale={locale}
+          hasBottomOverlay={showFilterPills}
         />
       )}
     </div>
@@ -236,6 +239,7 @@ function NoteListBody({
         noteListVirtuosoRef={noteListVirtuosoRef}
         locale={locale}
         loading={loading}
+        showFilterPills={showFilterPills}
       />
       {showFilterPills && (
         <FilterPills

--- a/src/components/note-list/NoteListViews.test.tsx
+++ b/src/components/note-list/NoteListViews.test.tsx
@@ -1,0 +1,32 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import { ListView } from './NoteListViews'
+import { makeEntry } from '../../test-utils/noteListTestUtils'
+import type { VaultEntry } from '../../types'
+
+const renderItem = (entry: VaultEntry) => <div data-testid="note-row">{entry.title}</div>
+
+const entries = [
+  makeEntry({ path: '/a.md', filename: 'a.md', title: 'Alpha' }),
+  makeEntry({ path: '/b.md', filename: 'b.md', title: 'Beta' }),
+]
+
+describe('ListView bottom overlay clearance', () => {
+  it('renders a bottom spacer so the last note can scroll above the filter pills overlay', () => {
+    render(<ListView searched={entries} query="" renderItem={renderItem} hasBottomOverlay />)
+
+    expect(screen.getByTestId('note-list-bottom-overlay-spacer')).toBeInTheDocument()
+  })
+
+  it('renders no spacer when there is no bottom overlay', () => {
+    render(<ListView searched={entries} query="" renderItem={renderItem} />)
+
+    expect(screen.queryByTestId('note-list-bottom-overlay-spacer')).not.toBeInTheDocument()
+  })
+
+  it('keeps the clearance in the empty state so the message stays above the overlay', () => {
+    render(<ListView searched={[]} query="" renderItem={renderItem} hasBottomOverlay />)
+
+    expect(screen.getByTestId('note-list-bottom-overlay-spacer')).toBeInTheDocument()
+  })
+})

--- a/src/components/note-list/NoteListViews.tsx
+++ b/src/components/note-list/NoteListViews.tsx
@@ -48,12 +48,24 @@ export function EntityView({ entity, groups, query, collapsedGroups, sortPrefs, 
   )
 }
 
-export function ListView({ isArchivedView, isChangesView, isInboxView, changesError, searched, query, renderItem, virtuosoRef, locale = 'en' }: {
+// The bottom filter pills float over the list, so scrollable content needs
+// matching clearance or the last note stays hidden underneath them.
+function BottomOverlaySpacer() {
+  return <div aria-hidden="true" data-testid="note-list-bottom-overlay-spacer" className="h-14" />
+}
+
+const BOTTOM_OVERLAY_COMPONENTS = { Footer: BottomOverlaySpacer }
+// Virtuoso crashes on an explicit `components={undefined}`, so fall back to
+// a stable empty object when no clearance is needed.
+const NO_EXTRA_COMPONENTS = {}
+
+export function ListView({ isArchivedView, isChangesView, isInboxView, changesError, searched, query, renderItem, virtuosoRef, locale = 'en', hasBottomOverlay }: {
   isArchivedView?: boolean; isChangesView?: boolean; isInboxView?: boolean; changesError?: string | null
   searched: VaultEntry[]; query: string
   renderItem: (entry: VaultEntry) => React.ReactNode
   virtuosoRef?: React.RefObject<VirtuosoHandle | null>
   locale?: AppLocale
+  hasBottomOverlay?: boolean
 }) {
   const emptyText = resolveEmptyText({
     isChangesView: !!isChangesView,
@@ -68,6 +80,7 @@ export function ListView({ isArchivedView, isChangesView, isInboxView, changesEr
     return (
       <div className="h-full overflow-y-auto">
         <EmptyMessage text={emptyText} />
+        {hasBottomOverlay && <BottomOverlaySpacer />}
       </div>
     )
   }
@@ -78,6 +91,7 @@ export function ListView({ isArchivedView, isChangesView, isInboxView, changesEr
       style={{ height: '100%' }}
       data={searched}
       overscan={200}
+      components={hasBottomOverlay ? BOTTOM_OVERLAY_COMPONENTS : NO_EXTRA_COMPONENTS}
       itemContent={(_index, entry) => renderItem(entry)}
     />
   )

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -89,16 +89,18 @@ vi.mock('react-virtuoso', () => ({
   Virtuoso: ({ data, itemContent, components }: {
     data?: unknown[]
     itemContent?: (index: number, item: unknown) => ReactNode
-    components?: { Header?: ComponentType }
+    components?: { Header?: ComponentType; Footer?: ComponentType }
   }) => {
     const Header = components?.Header
+    const Footer = components?.Footer
     const resolvedData = data ?? []
     const renderedIndexes = getVirtualizedIndexes(resolvedData.length)
     return createElement('div', { 'data-testid': 'virtuoso-mock' },
       Header ? createElement(Header) : null,
       renderedIndexes.map((index) =>
         createElement('div', { key: index }, itemContent?.(index, resolvedData[index]))
-      )
+      ),
+      Footer ? createElement(Footer) : null
     )
   },
   GroupedVirtuoso: ({ groupCounts, groupContent, itemContent }: {

--- a/tests/smoke/note-list-filter-pills-clearance.spec.ts
+++ b/tests/smoke/note-list-filter-pills-clearance.spec.ts
@@ -1,0 +1,43 @@
+import { test, expect } from '@playwright/test'
+
+test.describe('Note list filter pills clearance', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.route('**/api/vault/ping', route => route.fulfill({ status: 503 }))
+    await page.goto('/', { waitUntil: 'domcontentloaded' })
+    await expect(page.getByTestId('note-list-container')).toBeVisible({ timeout: 5_000 })
+  })
+
+  test('last note in a type view scrolls fully above the Open/Archived pills', async ({ page }) => {
+    await page.getByRole('button', { name: 'Projects', exact: true }).click()
+    const pills = page.getByTestId('filter-pills')
+    await expect(pills).toBeVisible({ timeout: 3_000 })
+
+    const scroller = page.locator('[data-testid="note-list-container"] [data-testid="virtuoso-scroller"]')
+    await expect(scroller).toBeVisible({ timeout: 3_000 })
+
+    // Virtualized scrollHeight grows as rows render, so keep jumping to the
+    // bottom and only measure once the scroll position and height have
+    // settled; otherwise a mid-relayout frame can hide the overlap.
+    let settledHeight = -1
+    await expect.poll(async () => {
+      const sample = await page.evaluate(() => {
+        const el = document.querySelector<HTMLElement>('[data-testid="note-list-container"] [data-testid="virtuoso-scroller"]')
+        const pillsEl = document.querySelector<HTMLElement>('[data-testid="filter-pills"]')
+        const rows = el?.querySelectorAll('.cursor-pointer')
+        const lastRow = rows?.[rows.length - 1]
+        if (!el || !pillsEl || !lastRow) return null
+        el.scrollTop = el.scrollHeight
+        return {
+          atBottom: el.scrollHeight - el.scrollTop - el.clientHeight < 1,
+          scrollHeight: el.scrollHeight,
+          overlap: lastRow.getBoundingClientRect().bottom - pillsEl.getBoundingClientRect().top,
+        }
+      })
+      if (!sample || !sample.atBottom || sample.scrollHeight !== settledHeight) {
+        settledHeight = sample?.scrollHeight ?? -1
+        return Number.POSITIVE_INFINITY
+      }
+      return sample.overlap
+    }, { timeout: 10_000 }).toBeLessThanOrEqual(0.5)
+  })
+})


### PR DESCRIPTION
## Problem

In type and folder views, the Open/Archived filter pills float over the bottom of the note list (`FilterPills` renders `absolute bottom-0` with a gradient background inside the list container). The scrollable list underneath has no matching clearance, so at maximum scroll the last row sits flush with the container bottom—exactly where the ~50px overlay is. The bottom of the last note is permanently hidden; no amount of scrolling can bring it clear of the pills.

**Repro:** open any type folder with enough notes to scroll, scroll the list to the bottom—the last entry is cut off behind the "Open / Archived" control.

<img width="557" height="270" alt="list-cut-off" src="https://github.com/user-attachments/assets/32d2e291-0387-4db9-b4f5-4316aeb1db10" />

## Fix

When the pills overlay is shown, `ListView` now renders a 56px spacer at the end of the scrollable content: a `Footer` component on the Virtuoso list, and the same spacer in the empty state. The final row can scroll fully above the overlay, and the gradient fade only ever covers content that can still be scrolled into view. Views without the pills are unchanged.

One implementation note: react-virtuoso crashes when `components` is passed explicitly as `undefined` (it overrides the internal default and then reads `components.EmptyPlaceholder`), so the no-overlay case passes a stable empty object instead.

## Tests

- New unit tests (`src/components/note-list/NoteListViews.test.tsx`) assert the spacer renders exactly when the overlay is present, for both the populated list and the empty state. The jsdom Virtuoso mock in `src/test/setup.ts` was extended to render `Footer`, mirroring its existing `Header` support.
- New Playwright spec (`tests/smoke/note-list-filter-pills-clearance.spec.ts`, regression lane, not `@smoke`-tagged) scrolls a type view to the bottom in real Chromium and asserts the last row's bottom edge sits above the pills, sampling only after the virtualized scroll height settles so the check is deterministic. Verified red → green: fails on every attempt without the fix, passes with it.

## Verification

- Full frontend unit suite: 5,056 tests across 478 files, all passing
- `pnpm lint`, `tsc --noEmit`, and `pnpm build` clean
- Frontend coverage 88.8% lines (≥70% gate)
- Curated Playwright smoke lane: 27/27 passing
- No Rust changes

CodeScene checks could not be run locally (no MCP/CLI/credentials on this machine); the change is a small additive component plus prop threading in already-healthy files.
